### PR TITLE
Add simple command line parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,21 @@ Function process via container provider
 
 ## Run
 
-    go run main.go
+```bash
+    go run main.go -contextDir=testDocker -imageName=python -dockerFile=Dockerfile 
+```
+
+You can also compile with _go build_ or build and install with _go install_ command then run it as a native executable.
+
+#### Parameters
+
+- -contextDir is the root directory where the Dockerfile, scripts, and other container dependencies are, by default current directory "./".
+
+- -imageName is the name of the image you want to start, if it does not exist it will be automatically generated and if it exists the system will just start the container.
+
+- -dockerFile is the name of the file containing the container settings, by default Dockerfile
+
+- -h Shows the list of parameters
+
+gofn generates the images with "gofn/" as a prefix.
 

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 
 	docker "github.com/fsouza/go-dockerclient"
@@ -9,6 +10,12 @@ import (
 )
 
 func main() {
+
+	contextDir := flag.String("contextDir", "./", "a string")
+	dockerFile := flag.String("dockerFile", "Dockerfile", "a string")
+	imageName := flag.String("imageName", "", "a string")
+	flag.Parse()
+
 	client := provision.FnClient("")
 
 	img, err := provision.FnFindImage(client, "python")
@@ -16,16 +23,16 @@ func main() {
 		panic(err)
 	}
 
-	var imageName string
+	var image string
 	var container *docker.Container
 
 	if img.ID == "" {
-		imageName, _ = provision.FnImageBuild(client, "testDocker", "Dockerfile", "python")
+		image, _ = provision.FnImageBuild(client, *contextDir, *dockerFile, *imageName)
 	} else {
-		imageName = "gofn/" + "python"
+		image = "gofn/" + (*imageName)
 	}
 
-	container, err = provision.FnContainer(client, imageName)
+	container, err = provision.FnContainer(client, image)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Adds simple parameters on the command line for easier testing.

Usage of gofn:
  -contextDir string
    	a string (default "./")
  -dockerFile string
    	a string (default "Dockerfile")
  -imageName string
    	a string
