### PR TITLE
Added enviroment variables on container options

### DIFF
--- a/examples/enviroment_vars/main.go
+++ b/examples/enviroment_vars/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/nuveo/gofn"
+	"github.com/nuveo/gofn/provision"
+)
+
+func main() {
+	buildOpts := &provision.BuildOptions{
+		ContextDir: "./testDocker",
+		ImageName:  "gofn/env",
+	}
+	containerOpts := &provision.ContainerOptions{
+		Env: []string{"FOO=bar", "KEY=value"},
+		Cmd: []string{"env"},
+	}
+	stdout, stderr, err := gofn.Run(buildOpts, containerOpts)
+	if err != nil {
+		log.Println(err)
+	}
+	fmt.Println("Stderr: ", stderr)
+	fmt.Println("Stdout: ", stdout)
+}

--- a/examples/enviroment_vars/testDocker/Dockerfile
+++ b/examples/enviroment_vars/testDocker/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:lastest

--- a/provision/docker.go
+++ b/provision/docker.go
@@ -42,6 +42,7 @@ type ContainerOptions struct {
 	Cmd     []string
 	Volumes []string
 	Image   string
+	Env     []string
 }
 
 // GetImageName sets preffix gofn when needed
@@ -73,6 +74,7 @@ func FnContainer(client *docker.Client, opts ContainerOptions) (container *docke
 	config := &docker.Config{
 		Image:     opts.Image,
 		Cmd:       opts.Cmd,
+		Env:       opts.Env,
 		StdinOnce: true,
 		OpenStdin: true,
 	}

--- a/provision/docker_test.go
+++ b/provision/docker_test.go
@@ -151,6 +151,31 @@ func TestFnContainerCreatedWithVolume(t *testing.T) {
 	}
 }
 
+func TestFnContainerCreatedWithEnvVars(t *testing.T) {
+
+	server := createFakeDockerAPI(t)
+	defer server.Stop()
+
+	// Instantiate a client
+	client := NewTestClient(server.URL(), t)
+	image := createFakeImage(client)
+
+	env := "GO=fn"
+	container, err := FnContainer(client, ContainerOptions{Image: image, Env: []string{env}})
+	if err != nil {
+		t.Errorf("Expected no errors but %q found", err)
+	}
+	// container name should starts with gofn
+	if !strings.HasPrefix(container.Name, "gofn") {
+		t.Errorf("container should starts with gofn but found %q", container.Name)
+	}
+	// enviroment variable is set in container
+	if container.Config.Env[0] != env {
+		t.Errorf("expected  %q bout found %q", env, container.Config.Env[0])
+	}
+
+}
+
 func TestFnBuildImageSuccessfully(t *testing.T) {
 	server := createFakeDockerAPI(t)
 	defer server.Stop()


### PR DESCRIPTION
Added enviroment variables on container options. Now you can pass enviroment variables as :

```go
containerOpts := &provision.ContainerOptions{
	Env: []string{"FOO=bar", "KEY=value"},
}

```