### PR TITLE
bug fix destroying container

### DIFF
--- a/gofn.go
+++ b/gofn.go
@@ -144,8 +144,8 @@ func Run(ctx context.Context, buildOpts *provision.BuildOptions, containerOpts *
 		log.Errorf("unable to kill container %v\n", container.ID)
 		return
 	}
-	log.Errorf("docker client is %#v\n", client, container)
-	log.Errorf("docker container is %#v\n", client, container)
+	log.Errorf("docker client is %#v\n", client)
+	log.Errorf("docker container is %#v\n", container)
 	return
 }
 

--- a/gofn.go
+++ b/gofn.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"time"
 
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/nuveo/gofn/iaas"
@@ -111,20 +112,40 @@ func Run(ctx context.Context, buildOpts *provision.BuildOptions, containerOpts *
 		log.Println("trying to destroy container process done")
 	}
 	if machine != nil {
-		derr := buildOpts.Iaas.DeleteMachine(machine)
-		if derr != nil {
-			log.Errorln(derr)
+		log.Printf("trying to delete machine ID:%v\n", machine.ID)
+		deleteErr := buildOpts.Iaas.DeleteMachine(machine)
+		if deleteErr != nil {
+			log.Errorln("error trying to delete machine ", deleteErr)
 		}
 		return
 	}
 	if client != nil && container != nil {
-		derr := DestroyContainer(context.Background(), client, container)
-		if derr != nil {
-			log.Errorln(derr)
+		for killAttempt := 0; killAttempt < 3; killAttempt++ {
+			if killAttempt > 0 {
+				<-time.After(time.Duration(3) * time.Second)
+			}
+			log.Printf("destroying container ID:%v, attempt:%v\n", container.ID, killAttempt+1)
+			err = client.KillContainer(docker.KillContainerOptions{ID: container.ID})
+			if err != nil {
+				log.Errorln("error trying to kill container ", err)
+			}
+			err = client.RemoveContainer(docker.RemoveContainerOptions{ID: container.ID})
+			if err != nil {
+				log.Errorln("error trying to remove container ", err)
+			}
+			_, err = provision.FnFindContainerByID(client, container.ID)
+			if err != nil {
+				if err == provision.ErrContainerNotFound {
+					err = nil
+				}
+				return
+			}
 		}
+		log.Errorf("unable to kill container %v\n", container.ID)
 		return
 	}
-	log.Errorln("docker client and container is nil")
+	log.Errorf("docker client is %#v\n", client, container)
+	log.Errorf("docker container is %#v\n", client, container)
 	return
 }
 

--- a/provision/docker.go
+++ b/provision/docker.go
@@ -132,10 +132,6 @@ func FnFindContainerByID(client *docker.Client, ID string) (container docker.API
 	}
 	for _, v := range containers {
 		if v.ID == ID {
-			fmt.Println("ID:", v.ID)
-			fmt.Println("Status:", v.Status)
-			fmt.Println("State:", v.State)
-
 			container = v
 			return
 		}

--- a/provision/docker.go
+++ b/provision/docker.go
@@ -123,6 +123,27 @@ func FnFindImage(client *docker.Client, imageName string) (image docker.APIImage
 	return
 }
 
+// FnFindContainerByID return container by ID
+func FnFindContainerByID(client *docker.Client, ID string) (container docker.APIContainers, err error) {
+	var containers []docker.APIContainers
+	containers, err = client.ListContainers(docker.ListContainersOptions{All: true})
+	if err != nil {
+		return
+	}
+	for _, v := range containers {
+		if v.ID == ID {
+			fmt.Println("ID:", v.ID)
+			fmt.Println("Status:", v.Status)
+			fmt.Println("State:", v.State)
+
+			container = v
+			return
+		}
+	}
+	err = ErrContainerNotFound
+	return
+}
+
 // FnFindContainer return container by image name
 func FnFindContainer(client *docker.Client, imageName string) (container docker.APIContainers, err error) {
 	var containers []docker.APIContainers

--- a/provision/docker_test.go
+++ b/provision/docker_test.go
@@ -290,6 +290,44 @@ func TestFnFindContainerSuccessfully(t *testing.T) {
 	}
 }
 
+func TestFnFindContainerByIDContainerNotFound(t *testing.T) {
+	server := createFakeDockerAPI(t)
+	defer server.Stop()
+
+	// Instantiate a client
+	client := NewTestClient(server.URL(), t)
+
+	// Find a container by image
+	if _, e := FnFindContainerByID(client, "python"); e != ErrContainerNotFound {
+		t.Errorf("Expected %q but found %q", ErrContainerNotFound, e)
+	}
+}
+
+func TestFnFindContainerByIDServerError(t *testing.T) {
+	client := NewTestClient("wrong", t)
+
+	_, err := FnFindContainerByID(client, "wrong")
+	if err == nil || err == ErrContainerNotFound {
+		t.Errorf("Expected other errors but found COntainerNotfound or null: %q", err)
+	}
+}
+
+func TestFnFindContainerByIDSuccessfully(t *testing.T) {
+	server := createFakeDockerAPI(t)
+	defer server.Stop()
+
+	// Instantiate a client
+	client := NewTestClient(server.URL(), t)
+
+	// Create container before find it
+	container := createFakeContainer(client, t)
+
+	// Find a container by image
+	if _, e := FnFindContainerByID(client, container.ID); e != nil {
+		t.Errorf("Expected no errors but %q found", e)
+	}
+}
+
 func TestFnFindContainerContainerNotFound(t *testing.T) {
 	server := createFakeDockerAPI(t)
 	defer server.Stop()


### PR DESCRIPTION
Just removing the container is not enough, you must first send the kill signal and then remove the container. This PR does this and validates if the container has actually destroyed, if it has not destroyed the system tries three times with an interval of three seconds between attempts.